### PR TITLE
Add Kafka service to docker-compose

### DIFF
--- a/dev-containers/docker-compose.yaml
+++ b/dev-containers/docker-compose.yaml
@@ -34,6 +34,25 @@ services:
       - "nifi_logs:/opt/nifi/nifi-current/logs"
       - "nifi_state:/opt/nifi/nifi-current/state"
       - "comfyui_models:/opt/nifi/nifi-current/downloads/models"
+  kafka:
+    image: docker.io/bitnami/kafka:3.9
+    hostname: "kafka"
+    container_name: "kafka"
+    ports:
+      - "9092:9092"
+    volumes:
+      - "kafka_data:/bitnami"
+    environment:
+      # KRaft settings
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      # Listeners
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
   mongodb:
     container_name: mongodb
     hostname: mongodb
@@ -84,7 +103,10 @@ volumes:
     external: true
   nifi_state:
     external: true
+  kafka_data:
+    external: true
   mongodb_data:
     external: true
   comfyui_models:
     external: true
+


### PR DESCRIPTION
Integrated Kafka into the docker-compose configuration, enabling a containerized instance of Kafka for testing and development. Included environment settings for KRaft and listener configurations, as well as volume support for persistent storage.