### PR TITLE
Add environment variables to Home Assistant container

### DIFF
--- a/home-containers/docker-compose.yaml
+++ b/home-containers/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     container_name: "homeassistant"
     hostname: "homeassistant"
     image: "ghcr.io/home-assistant/home-assistant:stable"
+    environment:
+      - NGINX_IP=${NGINX_IP}
+      - GH_TOKEN=${GH_TOKEN}
     ports:
       - "8123:8123/tcp"
     volumes:


### PR DESCRIPTION
Added `NGINX_IP` and `GH_TOKEN` as environment variables in the `docker-compose.yaml` file. This enhances configuration flexibility and supports dynamic setups for Home Assistant deployment.