### PR TITLE
Add marker-api service to docker-compose configuration

### DIFF
--- a/ai-containers/docker-compose.yaml
+++ b/ai-containers/docker-compose.yaml
@@ -17,6 +17,13 @@ services:
 #              count: 1
 #              capabilities: [gpu]
 
+  marker-api:
+    container_name: "marker-api"
+    hostname: "marker-api"
+    image: registry.thewisemans.io/marker-api
+    networks:
+      - ai-apps
+
   sdnext:
     container_name: "sdnext"
     hostname: "sdnext"


### PR DESCRIPTION
Introduced a new service, `marker-api`, to the docker-compose file. This service includes its container name, hostname, image, and network configuration, joining the `ai-apps` network.