### PR TITLE
Update Ollama image to version 0.5.8

### DIFF
--- a/ai-containers/docker-compose.yaml
+++ b/ai-containers/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - "serve"
     container_name: "ollama"
     hostname: "ollama"
-    image: "ollama/ollama:0.5.5"
+    image: "ollama/ollama:0.5.8"
     networks:
       - ai-apps
     volumes:


### PR DESCRIPTION
Upgraded the Docker image for the Ollama service from version 0.5.5 to 0.5.8. This ensures the service benefits from the latest updates, improvements, and potential bug fixes in the newer version.

Fixes #9 